### PR TITLE
Modify setup to properly package on PyPi

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,3 +19,15 @@ exclude = docs
 
 [aliases]
 # Define setup.py command aliases here
+
+[metadata]
+requires-dist =
+  six
+  future
+  metasub_utils.athena
+  metasub_utils.bridges
+  metasub_utils.hudson_alpha
+  metasub_utils.metadata
+  metasub_utils.metagenscope
+  metasub_utils.wasabi
+  metasub_utils.zurich

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ class InstallCmd(install):
 
 setup(
     name=PACKAGE_NAME,
-    version='0.4.0',
+    version='0.4.1',
     author='David Danko',
     author_email='dcdanko@gmail.com',
     description='Utility functions for the MetaSUB Consortium',
@@ -74,7 +74,7 @@ setup(
     install_requires=[
         'future',
         'six',
-    ],
+    ] + list(SOURCES.keys()),
     entry_points={
         'console_scripts': [
             'metasub=metasub_utils.cli:main'


### PR DESCRIPTION
Packaging microlibraries properly is tricky. It seems like the best current solution is to upload each microlib to PyPi individually then make the macrolib depend on them. 

This PR accomplishes that. Note that microlibs must be listed in both `setup.py` and `setup.cfg`